### PR TITLE
[etcd-druid-certs] Initial Chart

### DIFF
--- a/charts/etcd-druid-certs/.helmignore
+++ b/charts/etcd-druid-certs/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+ci/

--- a/charts/etcd-druid-certs/Chart.yaml
+++ b/charts/etcd-druid-certs/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: etcd-druid-certs
+description: Create Certificates and Issuers for an etcd-druid Etcd cluster
+type: application
+version: 1.0.0
+home: https://github.com/hajowieland/charts
+keywords:
+  - etcd
+  - etcd-druid
+  - cert-manager
+  - certificates
+maintainers:
+  - name: hajowieland
+    email: mail@wieland.tech
+sources:
+  - https://gardener.github.io/etcd-druid/
+  - https://github.com/gardener/etcd-druid
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: Initial commit of Chart

--- a/charts/etcd-druid-certs/README.md
+++ b/charts/etcd-druid-certs/README.md
@@ -1,0 +1,69 @@
+# etcd-druid-certs
+
+Create Certificates and Issuers for an etcd-druid Etcd cluster
+
+## TL;DR;
+
+```console
+helm repo add hajowieland https://charts.wieland.tech
+helm repo update
+helm install my-release hajowieland/etcd-druid-certs
+```
+
+## Introduction
+
+This chart deploys all certificate-related resources required to deploy etcd clusters via [etcd-druid](https://gardener.github.io/etcd-druid/).
+
+It creates [cert-manager](http://cert-manager.io) Custom Resources to deploy Issuers and Certificates for all etcd communication lines to be TLS encrypted.
+
+## Prerequisites
+
+- [cert-manager](http://cert-manager.io)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm repo add hajowieland https://charts.wieland.tech
+helm repo update
+helm install my-release hajowieland/etcd-druid-certs
+```
+
+These commands deploy Certicates & Issuers which are reconciled by cert-manager and can then be referenced in an etcd-druid `Etcd` Custom Resource.
+
+The [Values](#values) section lists the values that can be configured during installation.
+
+### Etcd
+
+The release name and replicas should match the name and desired replicas of the Etcd cluster you deploy the certificates for.
+Also note that it needs to be in the same Namespace as your Etcd.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall the `my-release` deployment:
+
+```console
+helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| etcdName | string | `""` | Set the name for the desired Etcd cluster - will be used in cert SANs |
+| privateKey | object | `{"algorithm":"RSA","size":4096}` | Certicate algorithm and size to be used in the private keys |
+| replicas | int | `3` | Replicas of the Etcd cluster |
+| subject | object | `{"organizationalUnits":["Kubernetes"],"organizations":["STACKX Cloud"]}` | Personalize the subject field in the certificates |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+helm install my-release -f values.yaml hajowieland/etcd-druid-certs
+```

--- a/charts/etcd-druid-certs/README.md.gotmpl
+++ b/charts/etcd-druid-certs/README.md.gotmpl
@@ -1,0 +1,61 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+## TL;DR;
+
+```console
+helm repo add hajowieland https://charts.wieland.tech
+helm repo update
+helm install my-release hajowieland/etcd-druid-certs
+```
+
+## Introduction
+
+This chart deploys all certificate-related resources required to deploy etcd clusters via [etcd-druid](https://gardener.github.io/etcd-druid/).
+
+It creates [cert-manager](http://cert-manager.io) Custom Resources to deploy Issuers and Certificates for all etcd communication lines to be TLS encrypted.
+
+## Prerequisites
+
+- [cert-manager](http://cert-manager.io)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm repo add hajowieland https://charts.wieland.tech
+helm repo update
+helm install my-release hajowieland/etcd-druid-certs
+```
+
+These commands deploy Certicates & Issuers which are reconciled by cert-manager and can then be referenced in an etcd-druid `Etcd` Custom Resource.
+
+The [Values](#values) section lists the values that can be configured during installation.
+
+### Etcd
+
+The release name and replicas should match the name and desired replicas of the Etcd cluster you deploy the certificates for.
+Also note that it needs to be in the same Namespace as your Etcd.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall the `my-release` deployment:
+
+```console
+helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+{{ template "chart.valuesSection" . }}
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+helm install my-release -f values.yaml hajowieland/etcd-druid-certs
+```

--- a/charts/etcd-druid-certs/ci/prepare.sh
+++ b/charts/etcd-druid-certs/ci/prepare.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Deploying cert-manager ..."
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.crds.yaml
+sleep 3
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.17.2

--- a/charts/etcd-druid-certs/ci/values-ci.yaml
+++ b/charts/etcd-druid-certs/ci/values-ci.yaml
@@ -1,0 +1,17 @@
+# -- Set the name for the desired Etcd cluster - will be used in cert SANs
+etcdName: "test"
+
+# -- Replicas of the Etcd cluster
+replicas: 3
+
+# -- Certicate algorithm and size to be used in the private keys
+privateKey:
+  algorithm: RSA
+  size: 4096
+
+# -- Personalize the subject field in the certificates
+subject:
+  organizations:
+    - ACME Org
+  organizationalUnits:
+    - Kind

--- a/charts/etcd-druid-certs/templates/_helpers.tpl
+++ b/charts/etcd-druid-certs/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "etcd-druid-certs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "etcd-druid-certs.labels" -}}
+helm.sh/chart: {{ include "etcd-druid-certs.chart" . }}
+{{ include "etcd-druid-certs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "etcd-druid-certs.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/etcd-druid-certs/templates/cert-etcd-backup-restore-ca.yaml
+++ b/charts/etcd-druid-certs/templates/cert-etcd-backup-restore-ca.yaml
@@ -1,0 +1,26 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.etcdName }}-etcd-backup-restore-ca
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "cert sign"
+  commonName: {{ .Values.etcdName }}-etcd-backup-restore-ca
+  subject:
+    organizations:
+      {{ toYaml .Values.subject.organizations }}
+    organizationalUnits:
+      {{ toYaml .Values.subject.organizationalUnits }}
+  secretName: {{ .Values.etcdName }}-etcd-backup-restore-ca-tls
+  privateKey:
+    algorithm: {{ .Values.privateKey.algorithm }}
+    size: {{ .Values.privateKey.size }}
+  issuerRef:
+    name: {{ .Values.etcdName }}-etcd-selfsigning-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/charts/etcd-druid-certs/templates/cert-etcd-backup-restore-client.yaml
+++ b/charts/etcd-druid-certs/templates/cert-etcd-backup-restore-client.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.etcdName }}-etcd-backup-restore-client
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  commonName: root
+  secretName: {{ .Values.etcdName }}-etcd-backup-restore-client-tls
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "client auth"
+  privateKey:
+    rotationPolicy: Always
+    algorithm: {{ .Values.privateKey.algorithm }}
+    size: {{ .Values.privateKey.size }}
+  issuerRef:
+    name: {{ .Values.etcdName }}-etcd-issuer
+    kind: Issuer

--- a/charts/etcd-druid-certs/templates/cert-etcd-backup-restore-server.yaml
+++ b/charts/etcd-druid-certs/templates/cert-etcd-backup-restore-server.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.etcdName }}-etcd-backup-restore-server
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.etcdName }}-etcd-backup-restore-server-tls
+  isCA: false
+  usages:
+    - "server auth"
+    - "signing"
+    - "key encipherment"
+  dnsNames:
+  - "{{ .Values.etcdName }}-local"
+  - localhost
+  - "127.0.0.1"
+  privateKey:
+    rotationPolicy: Always
+    algorithm: {{ .Values.privateKey.algorithm }}
+    size: {{ .Values.privateKey.size }}
+  issuerRef:
+    name: {{ .Values.etcdName }}-etcd-backup-restore-issuer

--- a/charts/etcd-druid-certs/templates/cert-etcd-ca.yaml
+++ b/charts/etcd-druid-certs/templates/cert-etcd-ca.yaml
@@ -1,0 +1,26 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.etcdName }}-etcd-ca
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "cert sign"
+  commonName: {{ .Values.etcdName }}-etcd-ca
+  subject:
+    organizations:
+      {{ toYaml .Values.subject.organizations }}
+    organizationalUnits:
+      {{ toYaml .Values.subject.organizationalUnits }}
+  secretName: {{ .Values.etcdName }}-etcd-ca-tls
+  privateKey:
+    algorithm: {{ .Values.privateKey.algorithm }}
+    size: {{ .Values.privateKey.size }}
+  issuerRef:
+    name: {{ .Values.etcdName }}-etcd-selfsigning-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/charts/etcd-druid-certs/templates/cert-etcd-client.yaml
+++ b/charts/etcd-druid-certs/templates/cert-etcd-client.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.etcdName }}-etcd-client
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  commonName: root
+  secretName: {{ .Values.etcdName }}-etcd-client-tls
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "client auth"
+  privateKey:
+    rotationPolicy: Always
+    algorithm: {{ .Values.privateKey.algorithm }}
+    size: {{ .Values.privateKey.size }}
+  issuerRef:
+    name: {{ .Values.etcdName }}-etcd-issuer
+    kind: Issuer

--- a/charts/etcd-druid-certs/templates/cert-etcd-peer-ca.yaml
+++ b/charts/etcd-druid-certs/templates/cert-etcd-peer-ca.yaml
@@ -1,0 +1,26 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.etcdName }}-etcd-peer-ca
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  isCA: true
+  usages:
+  - "signing"
+  - "key encipherment"
+  - "cert sign"
+  commonName: {{ .Values.etcdName }}-etcd-peer-ca
+  subject:
+    organizations:
+      {{ toYaml .Values.subject.organizations }}
+    organizationalUnits:
+      {{ toYaml .Values.subject.organizationalUnits }}
+  secretName: {{ .Values.etcdName }}-etcd-peer-ca-tls
+  privateKey:
+    algorithm: {{ .Values.privateKey.algorithm }}
+    size: {{ .Values.privateKey.size }}
+  issuerRef:
+    name: {{ .Values.etcdName }}-etcd-selfsigning-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/charts/etcd-druid-certs/templates/cert-etcd-peer.yaml
+++ b/charts/etcd-druid-certs/templates/cert-etcd-peer.yaml
@@ -1,0 +1,35 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.etcdName }}-etcd-peer
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.etcdName }}-etcd-peer-tls
+  isCA: false
+  usages:
+    - "server auth"
+    - "client auth"
+    - "signing"
+    - "key encipherment"
+  dnsNames:
+  - "{{ .Values.etcdName }}-local"
+  - "{{ .Values.etcdName }}-peer"
+  - "{{ .Values.etcdName }}-peer.{{ .Release.Namespace }}"
+  - "{{ .Values.etcdName }}-peer.{{ .Release.Namespace }}.svc"
+  - "{{ .Values.etcdName }}-peer.{{ .Release.Namespace }}.svc.cluster.local"
+  {{- $root := . -}}
+  {{- range $i := until (int .Values.replicas) }}
+  - "{{ $root.Values.etcdName }}-{{ $i }}.{{ $root.Values.etcdName }}-peer"
+  - "{{ $root.Values.etcdName }}-{{ $i }}.{{ $root.Values.etcdName }}-peer.{{ $root.Release.Namespace }}"
+  - "{{ $root.Values.etcdName }}-{{ $i }}.{{ $root.Values.etcdName }}-peer.{{ $root.Release.Namespace }}.svc"
+  - "{{ $root.Values.etcdName }}-{{ $i }}.{{ $root.Values.etcdName }}-peer.{{ $root.Release.Namespace }}.svc.cluster.local"
+  {{- end }}
+  - localhost
+  - "127.0.0.1"
+  privateKey:
+    rotationPolicy: Always
+    algorithm: {{ .Values.privateKey.algorithm }}
+    size: {{ .Values.privateKey.size }}
+  issuerRef:
+    name: {{ .Values.etcdName }}-etcd-peer-issuer

--- a/charts/etcd-druid-certs/templates/cert-etcd-server.yaml
+++ b/charts/etcd-druid-certs/templates/cert-etcd-server.yaml
@@ -1,0 +1,34 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.etcdName }}-etcd-server
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.etcdName }}-etcd-server-tls
+  isCA: false
+  usages:
+    - "server auth"
+    - "signing"
+    - "key encipherment"
+  dnsNames:
+  - "{{ .Values.etcdName }}-local"
+  - "{{ .Values.etcdName }}-client"
+  - "{{ .Values.etcdName }}-client.{{ .Release.Namespace }}"
+  - "{{ .Values.etcdName }}-client.{{ .Release.Namespace }}.svc"
+  - "{{ .Values.etcdName }}-client.{{ .Release.Namespace }}.svc.cluster.local"
+  {{- $root := . -}}
+  {{- range $i := until (int .Values.replicas) }}
+  - "{{ $root.Values.etcdName }}-{{ $i }}.{{ $root.Values.etcdName }}-peer"
+  - "{{ $root.Values.etcdName }}-{{ $i }}.{{ $root.Values.etcdName }}-peer.{{ $root.Release.Namespace }}"
+  - "{{ $root.Values.etcdName }}-{{ $i }}.{{ $root.Values.etcdName }}-peer.{{ $root.Release.Namespace }}.svc"
+  - "{{ $root.Values.etcdName }}-{{ $i }}.{{ $root.Values.etcdName }}-peer.{{ $root.Release.Namespace }}.svc.cluster.local"
+  {{- end }}
+  - localhost
+  - "127.0.0.1"
+  privateKey:
+    rotationPolicy: Always
+    algorithm: {{ .Values.privateKey.algorithm }}
+    size: {{ .Values.privateKey.size }}
+  issuerRef:
+    name: {{ .Values.etcdName }}-etcd-issuer

--- a/charts/etcd-druid-certs/templates/issuer-etcd-backup-restore-issuer.yaml
+++ b/charts/etcd-druid-certs/templates/issuer-etcd-backup-restore-issuer.yaml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.etcdName }}-etcd-backup-restore-issuer
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ .Values.etcdName }}-etcd-backup-restore-ca-tls

--- a/charts/etcd-druid-certs/templates/issuer-etcd-issuer.yaml
+++ b/charts/etcd-druid-certs/templates/issuer-etcd-issuer.yaml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.etcdName }}-etcd-issuer
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ .Values.etcdName }}-etcd-ca-tls

--- a/charts/etcd-druid-certs/templates/issuer-etcd-peer-issuer.yaml
+++ b/charts/etcd-druid-certs/templates/issuer-etcd-peer-issuer.yaml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.etcdName }}-etcd-peer-issuer
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ .Values.etcdName }}-etcd-peer-ca-tls

--- a/charts/etcd-druid-certs/templates/issuer-etcd-selfsigning-issuer.yaml
+++ b/charts/etcd-druid-certs/templates/issuer-etcd-selfsigning-issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.etcdName }}-etcd-selfsigning-issuer
+  labels:
+    {{- include "etcd-druid-certs.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}

--- a/charts/etcd-druid-certs/templates/validate.yaml
+++ b/charts/etcd-druid-certs/templates/validate.yaml
@@ -1,0 +1,3 @@
+{{- if not .Values.etcdName }}
+{{- fail "The name of the Etcd is required. Define the name in .Values.etcdName." }}
+{{- end }}

--- a/charts/etcd-druid-certs/values.schema.json
+++ b/charts/etcd-druid-certs/values.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "etcdName": {
+      "default": "",
+      "description": "Set the name for the desired Etcd cluster - will be used in cert SANs",
+      "required": [],
+      "title": "etcdName",
+      "type": "string"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "privateKey": {
+      "description": "Certicate algorithm and size to be used in the private keys",
+      "properties": {
+        "algorithm": {
+          "default": "RSA",
+          "required": [],
+          "title": "algorithm",
+          "type": "string"
+        },
+        "size": {
+          "default": 4096,
+          "required": [],
+          "title": "size",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "algorithm",
+        "size"
+      ],
+      "title": "privateKey",
+      "type": "object"
+    },
+    "replicas": {
+      "default": 3,
+      "description": "Replicas of the Etcd cluster",
+      "required": [],
+      "title": "replicas",
+      "type": "integer"
+    },
+    "subject": {
+      "description": "Personalize the subject field in the certificates",
+      "properties": {
+        "organizationalUnits": {
+          "items": {
+            "anyOf": [
+              {
+                "required": [],
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "required": [],
+          "title": "organizationalUnits",
+          "type": "array"
+        },
+        "organizations": {
+          "items": {
+            "anyOf": [
+              {
+                "required": [],
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "required": [],
+          "title": "organizations",
+          "type": "array"
+        }
+      },
+      "required": [
+        "organizations",
+        "organizationalUnits"
+      ],
+      "title": "subject",
+      "type": "object"
+    }
+  },
+  "required": [
+    "etcdName",
+    "replicas",
+    "privateKey",
+    "subject"
+  ],
+  "type": "object"
+}

--- a/charts/etcd-druid-certs/values.yaml
+++ b/charts/etcd-druid-certs/values.yaml
@@ -1,0 +1,17 @@
+# -- Set the name for the desired Etcd cluster - will be used in cert SANs
+etcdName: ""
+
+# -- Replicas of the Etcd cluster
+replicas: 3
+
+# -- Certicate algorithm and size to be used in the private keys
+privateKey:
+  algorithm: RSA
+  size: 4096
+
+# -- Personalize the subject field in the certificates
+subject:
+  organizations:
+    - STACKX Cloud
+  organizationalUnits:
+    - Kubernetes


### PR DESCRIPTION
#### What this PR does / why we need it

New Helm Chart for cert-manager Certificates & Issuers to be used for [etcd-druid](https://gardener.github.io/etcd-druid/).

#### Which issue this PR fixes

- fixes #8 

#### Checklist

- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[my-chart]`)
