### PR TITLE
[web-check]: Fix docs, increase API_TIMEOUT by default

### DIFF
--- a/charts/web-check/Chart.yaml
+++ b/charts/web-check/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: web-check
 description: A Helm chart for web-check all-in-one OSINT tool for analysing any website
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.0.0"
 home: https://github.com/hajowieland/charts
 icon: https://camo.githubusercontent.com/def1f3032b6ec59d11b109c906eb7a512796acbf46da8a7e53a3f1fa19fdcade/68747470733a2f2f692e6962622e636f2f7131675a4e32702f7765622d636865636b2d6c6f676f2e706e67

--- a/charts/web-check/README.md
+++ b/charts/web-check/README.md
@@ -23,8 +23,8 @@ API keys are required for the following external services:
 - `GOOGLE_CLOUD_API_KEY`: Google API key ([get here](https://cloud.google.com/api-gateway/docs/authenticate-api-keys)). This can be used to return quality metrics for a site
 - `REACT_APP_SHODAN_API_KEY`: Shodan API key ([get here](https://account.shodan.io/)). This will show associated host names for a given domain
 - `REACT_APP_WHO_API_KEY`: WhoAPI key ([get here](https://whoapi.com/)). This will show more comprehensive WhoIs records than the default job
-- `SECURITY_TRAILS_API_KEY` - Security Trails API key ([get here](https://securitytrails.com/corp/api)). This will show org info associated with the IP
-_ `TORRENT_IP_API_KEY`: A torrent API key ([get here](https://iknowwhatyoudownload.com/en/api/)). This will show torrents downloaded by an IP
+- `SECURITY_TRAILS_API_KEY` Security Trails API key ([get here](https://securitytrails.com/corp/api)). This will show org info associated with the IP
+- `TORRENT_IP_API_KEY`: A torrent API key ([get here](https://iknowwhatyoudownload.com/en/api/)). This will show torrents downloaded by an IP
 - `TRANCO_USERNAME` - Tranco email ([get here](https://tranco-list.eu/)). This will show the rank of a site, based on traffic
 - `TRANCO_API_KEY` - Tranco API key ([get here](https://tranco-list.eu/)). This will show the rank of a site, based on traffic
 - `URL_SCAN_API_KEY` - URLScan API key ([get here](https://urlscan.io/)). This will fetch miscalanious info about a site
@@ -66,7 +66,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | config.env.API_CORS_ORIGIN | string | `"*"` |  |
 | config.env.API_ENABLE_RATE_LIMIT | string | `"false"` |  |
-| config.env.API_TIMEOUT_LIMIT | string | `"10000"` |  |
+| config.env.API_TIMEOUT_LIMIT | string | `"60000"` |  |
 | config.env.DISABLE_GUI | string | `"false"` |  |
 | config.env.ENABLE_ANALYTICS | string | `"false"` |  |
 | config.env.PUPPETEER_EXECUTABLE_PATH | string | `"/usr/bin/chromium"` | see: https://github.com/Lissy93/web-check/issues/108#issuecomment-2307696851 |

--- a/charts/web-check/README.md.gotmpl
+++ b/charts/web-check/README.md.gotmpl
@@ -22,8 +22,8 @@ API keys are required for the following external services:
 - `GOOGLE_CLOUD_API_KEY`: Google API key ([get here](https://cloud.google.com/api-gateway/docs/authenticate-api-keys)). This can be used to return quality metrics for a site
 - `REACT_APP_SHODAN_API_KEY`: Shodan API key ([get here](https://account.shodan.io/)). This will show associated host names for a given domain
 - `REACT_APP_WHO_API_KEY`: WhoAPI key ([get here](https://whoapi.com/)). This will show more comprehensive WhoIs records than the default job
-- `SECURITY_TRAILS_API_KEY` - Security Trails API key ([get here](https://securitytrails.com/corp/api)). This will show org info associated with the IP
-_ `TORRENT_IP_API_KEY`: A torrent API key ([get here](https://iknowwhatyoudownload.com/en/api/)). This will show torrents downloaded by an IP
+- `SECURITY_TRAILS_API_KEY` Security Trails API key ([get here](https://securitytrails.com/corp/api)). This will show org info associated with the IP
+- `TORRENT_IP_API_KEY`: A torrent API key ([get here](https://iknowwhatyoudownload.com/en/api/)). This will show torrents downloaded by an IP
 - `TRANCO_USERNAME` - Tranco email ([get here](https://tranco-list.eu/)). This will show the rank of a site, based on traffic
 - `TRANCO_API_KEY` - Tranco API key ([get here](https://tranco-list.eu/)). This will show the rank of a site, based on traffic
 - `URL_SCAN_API_KEY` - URLScan API key ([get here](https://urlscan.io/)). This will fetch miscalanious info about a site

--- a/charts/web-check/values.schema.json
+++ b/charts/web-check/values.schema.json
@@ -60,7 +60,7 @@
               "type": "string"
             },
             "API_TIMEOUT_LIMIT": {
-              "default": "10000",
+              "default": "60000",
               "required": [],
               "title": "API_TIMEOUT_LIMIT",
               "type": "string"

--- a/charts/web-check/values.yaml
+++ b/charts/web-check/values.yaml
@@ -109,20 +109,20 @@ affinity: {}
 config:
   envSecrets:
     # Use this when using one k8s secret for multiply env secrets
-    # secretRef: librechat
+    # secretRef: web-check
 
     # Use this when using one k8s secret for each env secret
     secretKeyRef: []
-  #      - name: CREDS_IV
-  #        secretName: librechat
-  #        secretKey: CREDS_IV
+  #      - name: GOOGLE_CLOUD_API_KEY
+  #        secretName: web-check-secret
+  #        secretKey: googleApiKey
 
   env:
     # Full list of possible values
     # https://github.com/Lissy93/web-check/blob/master/.env
     API_CORS_ORIGIN: "*"
     API_ENABLE_RATE_LIMIT: "false"
-    API_TIMEOUT_LIMIT: "10000" # 10s
+    API_TIMEOUT_LIMIT: "60000" # 60s
     DISABLE_GUI: "false"
     ENABLE_ANALYTICS: "false"
     # -- see: https://github.com/Lissy93/web-check/issues/108#issuecomment-2307696851


### PR DESCRIPTION
#### What this PR does / why we need it

- Fix the list of API Keys in the docs to improve readability
- set default `API_TIMEOUT` from 10s --> 60s by default, as some longer running checks timeout otherwise

#### Which issue this PR fixes

--

#### Special notes for your reviewer

--

#### Checklist

- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[my-chart]`)
